### PR TITLE
Websocket thread-safety and perf fixes

### DIFF
--- a/HKTracker/HKTracker.cs
+++ b/HKTracker/HKTracker.cs
@@ -39,28 +39,14 @@ namespace HKTracker
             Instance = this;
             Log("Initializing PlayerDataDump");
             //Setup websockets server
-            _wss.AddWebSocketService<SocketServer>("/playerData", ss =>
-            {
-                ModHooks.NewGameHook += ss.NewGame;
-                ModHooks.AfterSavegameLoadHook += ss.LoadSave;
-                On.GameMap.Start += ss.gameMapStart;
-                ModHooks.SetPlayerBoolHook += ss.EchoBool;
-                ModHooks.SetPlayerIntHook += ss.EchoInt;
-                ModHooks.ApplicationQuitHook += ss.OnQuit;
-            });
+            _wss.AddWebSocketService<SocketServer>("/playerData");
 
             //Setup ProfileStorage Server
-            _wss.AddWebSocketService<ProfileStorageServer>("/ProfileStorage", ss => {
-                GlobalSettings.StyleEvent += ss.OnStyleEvent;
-                GlobalSettings.PresetEvent += ss.OnPresetEvent;
-                GlobalSettings.GlowEvent += ss.OnGlowEvent;
-                GlobalSettings.EquipColorEvent += ss.OnEquipColorEvent;
-                GlobalSettings.GaveColorEvent += ss.OnGaveColorEvent;
-            });
+            _wss.AddWebSocketService<ProfileStorageServer>("/ProfileStorage");
 
             _wss.Start();
             Log("Initialized PlayerDataDump");
-            
+
         }
         public List<IMenuMod.MenuEntry> GetMenuData(IMenuMod.MenuEntry? toggleButtonEntry)
         {
@@ -116,7 +102,7 @@ namespace HKTracker
                         "Minimal Right",
                         "Rando Racing"
                     },
-                    
+
                     Saver = opt => GS.TrackerProfile = (GlobalSettings.Profile)opt,
                     Loader = () => (int)GS.TrackerProfile
                 }

--- a/HKTracker/HKTracker.cs
+++ b/HKTracker/HKTracker.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Modding;
 using WebSocketSharp.Server;
-using WebSocketSharp;
 using System.Reflection;
 
 namespace HKTracker
@@ -20,7 +17,10 @@ namespace HKTracker
         public void OnLoadGlobal(GlobalSettings s) => GS = s;
         public override int LoadPriority() => 9999;
         private readonly WebSocketServer _wss = new WebSocketServer(11420);
-        ProfileStorageServer temp = new ProfileStorageServer();
+        /// <summary>
+        /// Used by websocket OnMessage callbacks to run tasks on the main game thread.
+        /// </summary>
+        internal UnityMainThreadTaskScheduler mainThreadScheduler;
         readonly string[] StyleValues = new string[] { "Classic", "Modern" };
         readonly string[] ColorValues = new string[] { "Default", "Red", "Green", "Blue", "Crimson", "Dark Red", "Pink", "Light Pink", "Hot Pink", "Orange", "Dark Orange", "Yellow", "Gold", "Purple", "Medium Purple", "Indigo", "Lime", "Chartreuse", "Yellow Green", "Turqoise", "Steel Blue", "Navy" };
         internal static HKTracker Instance;
@@ -37,6 +37,8 @@ namespace HKTracker
         public override void Initialize()
         {
             Instance = this;
+            mainThreadScheduler = new UnityMainThreadTaskScheduler();
+
             Log("Initializing PlayerDataDump");
             //Setup websockets server
             _wss.AddWebSocketService<SocketServer>("/playerData");
@@ -117,6 +119,7 @@ namespace HKTracker
             _wss.Stop();
             _wss.RemoveWebSocketService("/playerData");
             _wss.RemoveWebSocketService("/ProfileStorage");
+            mainThreadScheduler.Dispose();
         }
     }
 }

--- a/HKTracker/HKTracker.csproj
+++ b/HKTracker/HKTracker.csproj
@@ -76,6 +76,7 @@
     <Compile Include="GlobalSettings.cs" />
     <Compile Include="ProfileStorageServer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueuingWebSocketBehavior.cs" />
     <Compile Include="SocketServer.cs" />
     <Reference Include="UnityEngine">
       <HintPath>UnityEngine.dll</HintPath>

--- a/HKTracker/HKTracker.csproj
+++ b/HKTracker/HKTracker.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueuingWebSocketBehavior.cs" />
     <Compile Include="SocketServer.cs" />
+    <Compile Include="UnityMainThreadTaskScheduler.cs" />
     <Reference Include="UnityEngine">
       <HintPath>UnityEngine.dll</HintPath>
     </Reference>

--- a/HKTracker/ProfileStorageServer.cs
+++ b/HKTracker/ProfileStorageServer.cs
@@ -64,20 +64,19 @@ namespace HKTracker
                 }
             } else if (e.Data.StartsWith("OBSGetPreset"))
             {
-                OnPresetEvent();
-                
+                HKTracker.Instance.mainThreadScheduler.Factory.StartNew(OnPresetEvent);
             } else if (e.Data.StartsWith("OBSGetStyle"))
             {
-                OnStyleEvent();
+                HKTracker.Instance.mainThreadScheduler.Factory.StartNew(OnStyleEvent);
             } else if (e.Data.StartsWith("OBSGetGlow"))
             {
-                OnGlowEvent();
+                HKTracker.Instance.mainThreadScheduler.Factory.StartNew(OnGlowEvent);
             } else if (e.Data.StartsWith("OBSGetEquipC"))
             {
-                OnEquipColorEvent();
+                HKTracker.Instance.mainThreadScheduler.Factory.StartNew(OnEquipColorEvent);
             } else if (e.Data.StartsWith("OBSGetGaveC"))
             {
-                OnGaveColorEvent();
+                HKTracker.Instance.mainThreadScheduler.Factory.StartNew(OnGaveColorEvent);
             } else
             {
                 QueuedSend("load|int,save|int|{data}");

--- a/HKTracker/ProfileStorageServer.cs
+++ b/HKTracker/ProfileStorageServer.cs
@@ -4,11 +4,10 @@ using System.IO;
 using System.Text;
 using UnityEngine;
 using WebSocketSharp;
-using WebSocketSharp.Server;
 
 namespace HKTracker
 {
-    internal class ProfileStorageServer : WebSocketBehavior
+    internal class ProfileStorageServer : QueuingWebSocketBehavior
     {
         Dictionary<string, string> HexColor = new Dictionary<string, string>
         {
@@ -53,7 +52,7 @@ namespace HKTracker
                 string[] temp = e.Data.Split('|');
                 if (int.TryParse(temp[1], out int profileId))
                 {
-                    Send(profileId + "|" + GetProfile(profileId));
+                    QueuedSend(profileId + "|" + GetProfile(profileId));
                 }
             } else if (e.Data.StartsWith("save"))
             {
@@ -81,7 +80,7 @@ namespace HKTracker
                 OnGaveColorEvent();
             } else
             {
-                Send("load|int,save|int|{data}");
+                QueuedSend("load|int,save|int|{data}");
             }
         }
 
@@ -132,29 +131,29 @@ namespace HKTracker
         public void OnStyleEvent()
         {
             HKTracker.Instance.LogDebug("sending: " + "Style|" + HKTracker.GS.TrackerStyle);
-            Send("Style|" + HKTracker.GS.TrackerStyle);
+            QueuedSend("Style|" + HKTracker.GS.TrackerStyle);
         }
         public void OnPresetEvent()
         {
             HKTracker.Instance.LogDebug("sending: " + "Preset|" + HKTracker.GS.TrackerProfile);
-            Send("Preset|" + HKTracker.GS.TrackerProfile);
+            QueuedSend("Preset|" + HKTracker.GS.TrackerProfile);
         }
         public void OnGlowEvent()
         {
             HKTracker.Instance.LogDebug("sending: " + "BorderGlow|" + HKTracker.GS.TrackerGlow);
-            Send("BorderGlow|" + HKTracker.GS.TrackerGlow);
+            QueuedSend("BorderGlow|" + HKTracker.GS.TrackerGlow);
         }
         public void OnEquipColorEvent()
         {
             HexColor.TryGetValue(HKTracker.GS.EquipColor.ToString(), out string temp);
             HKTracker.Instance.LogDebug("sending: " + "EquipColor|" + temp);
-            Send("EquipColor|" + temp);
+            QueuedSend("EquipColor|" + temp);
         }
         public void OnGaveColorEvent()
         {
             HexColor.TryGetValue(HKTracker.GS.GaveColor.ToString(), out string temp);
             HKTracker.Instance.LogDebug("sending: " + "GaveColor|" + temp);
-            Send("GaveColor|" + temp);
+            QueuedSend("GaveColor|" + temp);
         }
     }
 }

--- a/HKTracker/ProfileStorageServer.cs
+++ b/HKTracker/ProfileStorageServer.cs
@@ -115,17 +115,25 @@ namespace HKTracker
         protected override void OnClose(CloseEventArgs e)
         {
             base.OnClose(e);
+
             GlobalSettings.StyleEvent -= OnStyleEvent;
             GlobalSettings.PresetEvent -= OnPresetEvent;
             GlobalSettings.GlowEvent -= OnGlowEvent;
             GlobalSettings.EquipColorEvent -= OnEquipColorEvent;
             GlobalSettings.GaveColorEvent -= OnGaveColorEvent;
+
             HKTracker.Instance.Log("[ProfileStorage] CLOSE: Code:" + e.Code + ", Reason:" + e.Reason);
         }
 
         protected override void OnOpen()
         {
             HKTracker.Instance.Log("[ProfileStorage] OPEN");
+
+            GlobalSettings.StyleEvent += OnStyleEvent;
+            GlobalSettings.PresetEvent += OnPresetEvent;
+            GlobalSettings.GlowEvent += OnGlowEvent;
+            GlobalSettings.EquipColorEvent += OnEquipColorEvent;
+            GlobalSettings.GaveColorEvent += OnGaveColorEvent;
         }
 
         public void OnStyleEvent()

--- a/HKTracker/QueuingWebSocketBehavior.cs
+++ b/HKTracker/QueuingWebSocketBehavior.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using WebSocketSharp;
+using WebSocketSharp.Server;
+
+namespace HKTracker
+{
+    internal abstract class QueuingWebSocketBehavior : WebSocketBehavior
+    {
+        private Task readyToWrite = Task.CompletedTask;
+        private readonly CancellationTokenSource connectionClosed = new CancellationTokenSource();
+
+        /// <summary>Queue data to send on the websocket in-order. This method is thread-safe and non-blocking.</summary>
+        protected void QueuedSend(string data)
+        {
+            var promise = new TaskCompletionSource<object>();
+            var oldReadyToWrite = Interlocked.Exchange(ref readyToWrite, promise.Task);
+            oldReadyToWrite.ContinueWith(t =>
+            {
+                SendAsync(data, b =>
+                {
+                    promise.SetResult(null);
+                });
+            }, connectionClosed.Token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+
+        protected override void OnClose(CloseEventArgs e)
+        {
+            base.OnClose(e);
+            connectionClosed.Cancel();
+        }
+    }
+}

--- a/HKTracker/SocketServer.cs
+++ b/HKTracker/SocketServer.cs
@@ -5,6 +5,7 @@ using Modding;
 using WebSocketSharp;
 using UnityEngine;
 using Newtonsoft.Json;
+
 namespace HKTracker
 {
     internal class SocketServer : QueuingWebSocketBehavior
@@ -36,49 +37,52 @@ namespace HKTracker
         {
             if (State != WebSocketState.Open) return;
 
-            switch (e.Data)
+            HKTracker.Instance.mainThreadScheduler.Factory.StartNew(() =>
             {
-                case "mods":
-                    QueuedSend(JsonUtility.ToJson(ModHooks.LoadedModsWithVersions));
-                    break;
-                case "version":
-                    QueuedSend($"{{ \"version\":\"{HKTracker.Instance.GetVersion()}\" }}");
-                    break;
-                case "json":
-                    QueuedSend(GetJson());
-                    GetNail();
-                    GetDash();
-                    GetClaw();
-                    GetCDash();
-                    GetRandom();
-                    GetSwim();
-                    GetEPass();
-                    GetFocus();
-                    break;
-                default:
-                    if (e.Data.Contains('|'))
-                    {
-                        switch (e.Data.Split('|')[0])
+                switch (e.Data)
+                {
+                    case "mods":
+                        QueuedSend(JsonUtility.ToJson(ModHooks.LoadedModsWithVersions));
+                        break;
+                    case "version":
+                        QueuedSend($"{{ \"version\":\"{HKTracker.Instance.GetVersion()}\" }}");
+                        break;
+                    case "json":
+                        QueuedSend(GetJson());
+                        GetNail();
+                        GetDash();
+                        GetClaw();
+                        GetCDash();
+                        GetRandom();
+                        GetSwim();
+                        GetEPass();
+                        GetFocus();
+                        break;
+                    default:
+                        if (e.Data.Contains('|'))
                         {
-                            case "bool":
-                                string b = PlayerData.instance.GetBool(e.Data.Split('|')[1]).ToString();
-                                SendMessage(e.Data.Split('|')[1], b);
-                                break;
-                            case "int":
-                                string i = PlayerData.instance.GetInt(e.Data.Split('|')[1]).ToString();
-                                SendMessage(e.Data.Split('|')[1], i);
-                                break;
-                            case "Exception":
-                                HKTracker.Instance.LogError("PlayerData contains invalid data at: " + e.Data.Split('|')[1]);
-                                break;
+                            switch (e.Data.Split('|')[0])
+                            {
+                                case "bool":
+                                    string b = PlayerData.instance.GetBool(e.Data.Split('|')[1]).ToString();
+                                    SendMessage(e.Data.Split('|')[1], b);
+                                    break;
+                                case "int":
+                                    string i = PlayerData.instance.GetInt(e.Data.Split('|')[1]).ToString();
+                                    SendMessage(e.Data.Split('|')[1], i);
+                                    break;
+                                case "Exception":
+                                    HKTracker.Instance.LogError("PlayerData contains invalid data at: " + e.Data.Split('|')[1]);
+                                    break;
+                            }
                         }
-                    }
-                    else
-                    {
-                        QueuedSend("mods,version,json,bool|{var},int|{var}");
-                    }
-                    break;
-            }
+                        else
+                        {
+                            QueuedSend("mods,version,json,bool|{var},int|{var}");
+                        }
+                        break;
+                }
+            });
         }
 
         protected override void OnError(WebSocketSharp.ErrorEventArgs e)
@@ -136,7 +140,6 @@ namespace HKTracker
 
         public bool EchoBool(string var, bool value)
         {
-            
             HKTracker.Instance.LogDebug($"EchoBool: {var} = {value}");
             if (var == "atBench" && value && !RandoAtBench)
             {

--- a/HKTracker/SocketServer.cs
+++ b/HKTracker/SocketServer.cs
@@ -96,6 +96,7 @@ namespace HKTracker
             ModHooks.SetPlayerIntHook -= EchoInt;
             On.GameMap.Start -= gameMapStart;
             ModHooks.ApplicationQuitHook -= OnQuit;
+
             HKTracker.Instance.Log("CLOSE: Code:" + e.Code + ", Reason:" + e.Reason);
         }
 
@@ -104,6 +105,13 @@ namespace HKTracker
         protected override void OnOpen()
         {
             HKTracker.Instance.Log("OPEN");
+
+            ModHooks.NewGameHook += NewGame;
+            ModHooks.AfterSavegameLoadHook += LoadSave;
+            ModHooks.SetPlayerBoolHook += EchoBool;
+            ModHooks.SetPlayerIntHook += EchoInt;
+            On.GameMap.Start += gameMapStart;
+            ModHooks.ApplicationQuitHook += OnQuit;
         }
 
         public void SendMessage(string var, string value)

--- a/HKTracker/SocketServer.cs
+++ b/HKTracker/SocketServer.cs
@@ -3,12 +3,11 @@ using System.Linq;
 using System.IO;
 using Modding;
 using WebSocketSharp;
-using WebSocketSharp.Server;
 using UnityEngine;
 using Newtonsoft.Json;
 namespace HKTracker
 {
-    internal class SocketServer : WebSocketBehavior
+    internal class SocketServer : QueuingWebSocketBehavior
     {
         public SocketServer()
         {
@@ -40,13 +39,13 @@ namespace HKTracker
             switch (e.Data)
             {
                 case "mods":
-                    Send(JsonUtility.ToJson(ModHooks.LoadedModsWithVersions));
+                    QueuedSend(JsonUtility.ToJson(ModHooks.LoadedModsWithVersions));
                     break;
                 case "version":
-                    Send($"{{ \"version\":\"{HKTracker.Instance.GetVersion()}\" }}");
+                    QueuedSend($"{{ \"version\":\"{HKTracker.Instance.GetVersion()}\" }}");
                     break;
                 case "json":
-                    Send(GetJson());
+                    QueuedSend(GetJson());
                     GetNail();
                     GetDash();
                     GetClaw();
@@ -76,7 +75,7 @@ namespace HKTracker
                     }
                     else
                     {
-                        Send("mods,version,json,bool|{var},int|{var}");
+                        QueuedSend("mods,version,json,bool|{var},int|{var}");
                     }
                     break;
             }
@@ -110,7 +109,7 @@ namespace HKTracker
         public void SendMessage(string var, string value)
         {
             if (State != WebSocketState.Open) return;
-            Send(new Row(var, value).ToJsonElementPair);
+            QueuedSend(new Row(var, value).ToJsonElementPair);
         }
 
         public void LoadSave(SaveGameData data)

--- a/HKTracker/UnityMainThreadTaskScheduler.cs
+++ b/HKTracker/UnityMainThreadTaskScheduler.cs
@@ -1,0 +1,123 @@
+﻿#nullable enable
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace HKTracker
+{
+    /// Loosely based on
+    /// https://github.com/nike4613/BeatSaber-IPA-Reloaded/blob/145879a186f99170142886b7ed04f5660fada830/IPA.Loader/Utilities/Async/UnityMainThreadTaskScheduler.cs
+    internal class UnityMainThreadTaskScheduler : TaskScheduler, IDisposable
+    {
+        public readonly TaskFactory Factory;
+
+        private class SchedulerComponent : MonoBehaviour
+        {
+            internal UnityMainThreadTaskScheduler? outer;
+
+            void Awake()
+            {
+                DontDestroyOnLoad(this);
+            }
+
+            void Update()
+            {
+                while (outer!.tasks.TryDequeue(out QueueItem task))
+                {
+                    if (task.Task is not null)
+                    {
+                        outer.TryExecuteTask(task.Task);
+                    }
+                }
+            }
+        }
+
+        private readonly Thread mainThread;
+        private readonly GameObject gameObject;
+
+        private readonly ConcurrentQueue<QueueItem> tasks = new();
+        private static readonly ConditionalWeakTable<Task, QueueItem> itemTable = new();
+
+        private class QueueItem
+        {
+            public Task? Task;
+
+            public QueueItem(Task task)
+            {
+                Task = task;
+            }
+        }
+
+        /// <summary>
+        /// Needs to be instantiated on the main game thread.
+        /// </summary>
+        public UnityMainThreadTaskScheduler()
+        {
+            mainThread = Thread.CurrentThread;
+            gameObject = new GameObject("HKTracker_UnityMainThreadTaskScheduler");
+            gameObject.AddComponent<SchedulerComponent>().outer = this;
+            Factory = new TaskFactory(this);
+        }
+
+        protected override IEnumerable<Task> GetScheduledTasks()
+            => tasks.ToArray().Where(q => q.Task is not null).Select(q => q.Task!).ToArray();
+
+        protected override void QueueTask(Task task)
+        {
+            ThrowIfDisposed();
+
+            var item = new QueueItem(task);
+            itemTable.Add(task, item);
+            tasks.Enqueue(item);
+        }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            ThrowIfDisposed();
+
+            if (!mainThread.Equals(Thread.CurrentThread))
+            {
+                return false;
+            }
+            if (taskWasPreviouslyQueued)
+            {
+                if (itemTable.TryGetValue(task, out var item))
+                {
+                    item.Task = null;
+                }
+                else return false;
+            }
+            return TryExecuteTask(task);
+        }
+
+        #region IDisposable Support
+        private bool disposedValue;
+
+        private void ThrowIfDisposed()
+        {
+            if (disposedValue)
+                throw new ObjectDisposedException(nameof(UnityMainThreadTaskScheduler));
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                UnityEngine.Object.Destroy(gameObject);
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
I noticed two issues with this mod: it did blocking IO with websockets on the main thread which can interrupt the game, and it unsafely accessed data owned by the game thread in the websockets' OnMessage method which is called from a separate thread and could cause game data corruption.

This PR fixes both issues. The first commit fixes the first issue by using async IO, the second commit is some very minor reorganizing to make some code clearer, and the third commit fixes the second issue.

I have previously contributed very similar fixes to two other game mods (Beat Saber) that used the same websocket-sharp library and had the same issues as this mod has: https://github.com/opl-/beatsaber-http-status/pull/60, https://github.com/ReadieFur/BSDataPuller/pull/10.